### PR TITLE
Update -break-insert with the -f (pending flag) to not require an additional parameter

### DIFF
--- a/src/MICmdCmdBreak.cpp
+++ b/src/MICmdCmdBreak.cpp
@@ -80,8 +80,7 @@ bool CMICmdCmdBreakInsert::ParseArgs() {
   // Not implemented m_setCmdArgs.Add(new CMICmdArgValOptionShort(
   // m_constStrArgNamedHWBrkPt, false, false));
   m_setCmdArgs.Add(new CMICmdArgValOptionShort(
-      m_constStrArgNamedPendinfBrkPt, false, true,
-      CMICmdArgValListBase::eArgValType_StringQuotedNumberPath, 1));
+      m_constStrArgNamedPendinfBrkPt, false, true));
   m_setCmdArgs.Add(new CMICmdArgValOptionShort(m_constStrArgNamedDisableBrkPt,
                                                false, false));
   // Not implemented m_setCmdArgs.Add(new CMICmdArgValOptionShort(


### PR DESCRIPTION
Fixes: https://bugs.llvm.org/show_bug.cgi?id=28698

According to [this](https://sourceware.org/gdb/onlinedocs/gdb/GDB_002fMI-Breakpoint-Commands.html#GDB_002fMI-Breakpoint-Commands) document, `-break-insert`'s `-f` flag is to tell the debugger to create a pending breakpoint if the location is not found. The additional parameter should not be necessary.

```
‘-f’
If location cannot be parsed (for example if it refers to unknown files or functions), create a pending breakpoint. Without this flag, GDB will report an error, and won’t create a breakpoint, if location cannot be parsed.

‘-d’
```