### PR TITLE
Simplify linked libraries: LLVMSupport -> LLVM

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,4 +74,4 @@ add_executable(lldb-mi
   MIUtilVariant.cpp
 )
 
-target_link_libraries(lldb-mi lldb LLVMSupport)
+target_link_libraries(lldb-mi lldb LLVM pthread)


### PR DESCRIPTION
Fedora 30 has libLLVMSupport only in 'llvm-static' which does not need to be
installed:
```
	[100%] Linking CXX executable lldb-mi
	/usr/bin/ld: cannot find -lLLVMSupport
	collect2: error: ld returned 1 exit status
```

Also I had some compatibility problem linking both static and dynamic libraries:
```
	: CommandLine Error: Option 'disable-symbolication' registered more than once!
	LLVM ERROR: inconsistency in registered CommandLine options
```
