### PR TITLE
Change minimum required cmake version to match llvm.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.4.3)
 project(lldb-mi)
 
 


### PR DESCRIPTION
llvm's minimum required cmake version is 3.4.3. This changes lldb-mi's requirement from 3.11 to 3.4.3, to match llvm.