### PR TITLE
Use llvm cmake module to set stdlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ find_package(LLVM REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
+list(APPEND CMAKE_MODULE_PATH ${LLVM_DIR})
+include(HandleLLVMStdlib)
+
 include_directories(${LLVM_INCLUDE_DIRS})
 if(LLVM_BUILD_MAIN_SRC_DIR)
   include_directories(${LLVM_BUILD_MAIN_SRC_DIR}/tools/clang/include)
@@ -15,8 +18,6 @@ link_directories(${LLVM_LIBRARY_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 
 add_definitions(-D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS)
-
-set(CMAKE_CXX_STANDARD 11)
 
 add_subdirectory(src)
 


### PR DESCRIPTION
set(CMAKE_CXX_STANDARD 11) will pass -std=gnu++11, which breaks builds that use libc++ instead of libstdc++. Instead of that, use the llvm cmake module HandleLLVMStdlib.cmake.