### PR TITLE
Include HandleLLVMOptions.cmake to inherit common compile flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.4.3)
+
+if(POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif()
+
 project(lldb-mi)
 
 
@@ -8,6 +13,7 @@ message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
 list(APPEND CMAKE_MODULE_PATH ${LLVM_DIR})
 include(HandleLLVMStdlib)
+include(HandleLLVMOptions)
 
 include_directories(${LLVM_INCLUDE_DIRS})
 if(LLVM_BUILD_MAIN_SRC_DIR)
@@ -16,8 +22,6 @@ if(LLVM_BUILD_MAIN_SRC_DIR)
 endif()
 link_directories(${LLVM_LIBRARY_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
-
-add_definitions(-D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS)
 
 add_subdirectory(src)
 


### PR DESCRIPTION
HandleLLVMOption is where flags like -std are set in LLVM. Instead of duplicating
that logic, include this file in lldb-mi as well.

Also set the CMP0077 policy like LLVM does so that we don't get warnings.

Closes #17

Signed-off-by: Marc-Andre Laperle <malaperle@gmail.com>