### PR TITLE
Tweak Jan Kratochvil's "Simplify linked libraries: LLVMSupport -> LLVM"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,4 +74,4 @@ add_executable(lldb-mi
   MIUtilVariant.cpp
 )
 
-target_link_libraries(lldb-mi lldb LLVMSupport pthread)
+target_link_libraries(lldb-mi lldb `llvm-config --libs` pthread)


### PR DESCRIPTION
change.

Don't hardcode LLVM (or LLVMSupport), but use: `llvm-config --libs`