### PR TITLE
Link libraries from the LLVM_LIBRARY_DIRS location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if(LLVM_BUILD_MAIN_SRC_DIR)
   include_directories(${LLVM_BUILD_MAIN_SRC_DIR}/tools/clang/include)
   include_directories(${LLVM_BUILD_BINARY_DIR}/tools/clang/include)
 endif()
-link_directories(${LLVM_LIBRARY_DIRS})
+
 add_definitions(${LLVM_DEFINITIONS})
 
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,4 +74,25 @@ add_executable(lldb-mi
   MIUtilVariant.cpp
 )
 
-target_link_libraries(lldb-mi lldb LLVMSupport pthread)
+set(llvm_deps "")
+
+find_library(liblldb lldb HINTS ${LLVM_LIBRARY_DIRS})
+find_library(libllvm LLVM HINTS ${LLVM_LIBRARY_DIRS})
+
+if (NOT libllvm)
+  message(STATUS "Can't find LLVM shared library, falling back to static linking LLVMSupport")
+  find_library(libllvm LLVMSupport HINTS ${LLVM_LIBRARY_DIRS})
+  find_package(Curses REQUIRED)
+  
+  get_property(LLVMSupportDeps GLOBAL PROPERTY LLVMBUILD_LIB_DEPS_LLVMSupport)
+  foreach(dependency ${LLVMSupportDeps})
+    find_library(lib ${dependency} HINTS ${LLVM_LIBRARY_DIRS})
+    list(APPEND llvm_deps "${lib}")
+  endforeach()
+  
+  list(APPEND llvm_deps "${CURSES_LIBRARIES}")
+endif()
+  
+list(APPEND llvm_deps "${LLVM_PTHREAD_LIB}")
+
+target_link_libraries(lldb-mi ${liblldb} ${libllvm} ${llvm_deps})


### PR DESCRIPTION
This commit fixes runtime error
```
: CommandLine Error: Option 'disable-symbolication' registered more than once!
LLVM ERROR: inconsistency in registered CommandLine options
```

Linking only the LLVMSupport from the same location also led to this error (i.e. an another LLVM shared library was loaded at runtime?)

Should also fix #8 