### PR TITLE
Add 'pending-breakpoints' to 'list-features' list

### DIFF
--- a/src/MICmdCmdSupportList.cpp
+++ b/src/MICmdCmdSupportList.cpp
@@ -69,10 +69,12 @@ bool CMICmdCmdSupportListFeatures::Acknowledge() {
   // Declare supported features here
   const CMICmnMIValueConst miValueConst1("data-read-memory-bytes");
   const CMICmnMIValueConst miValueConst2("exec-run-start-option");
+  const CMICmnMIValueConst miValueConst3("pending-breakpoints");
   // Some features may depend on host and/or target, decide what to add below
   CMICmnMIValueList miValueList(true);
   miValueList.Add(miValueConst1);
   miValueList.Add(miValueConst2);
+  miValueList.Add(miValueConst3);
   const CMICmnMIValueResult miValueResult("features", miValueList);
   const CMICmnMIResultRecord miRecordResult(
       m_cmdData.strMiCmdToken, CMICmnMIResultRecord::eResultClass_Done,


### PR DESCRIPTION
Adding `pending-breakpoints` to the list to indicate that there
is support for the -f option to the `-break-insert` command.

[Documentation ](https://sourceware.org/gdb/onlinedocs/gdb/GDB_002fMI-Support-Commands.html#GDB_002fMI-Support-Commands) from GDB-MI 

Support is seen in
https://github.com/lldb-tools/lldb-mi/blob/1fa7523e9f4988d63e77974fb660bbd9976bd036/src/MICmdCmdBreak.cpp#L46
and parsing is in
https://github.com/lldb-tools/lldb-mi/blob/1fa7523e9f4988d63e77974fb660bbd9976bd036/src/MICmdCmdBreak.cpp#L83