### PR TITLE
Build lldb-mi with LLDB.framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,12 @@ project(lldb-mi)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+if (USE_LLDB_FRAMEWORK AND !APPLE)
+  message(FATAL_ERROR "USE_LLDB_FRAMEWORK is only avaliable on Darwin")
+endif()
+
 find_package(LLVM REQUIRED CONFIG)
+
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 

--- a/README.md
+++ b/README.md
@@ -46,3 +46,19 @@ cd build
 cmake -DCMAKE_PREFIX_PATH=~/buildspace/llvm-inst/ -GNinja ..
 ninja
 ```
+
+# Building against custom LLDB.framework (Darwin Only)
+
+You can also build lldb-mi against a LLDB.framework that you compiled yourself. It is the same instructions as above but build the LLVM framework by passing `-DLLDB_BUILD_FRAMEWORK=1` to CMake instead of using the shared library. Then build LLDB-MI with `-DUSE_LLDB_FRAMEWORK=1`
+
+The snippits below change the cmake calls from the above script.
+```
+// Building llvm-project
+cmake -DLLVM_ENABLE_PROJECTS="clang;lldb;libcxx;libcxxabi" -DCMAKE_INSTALL_PREFIX=~/buildspace/llvm-inst/ -DLLDB_BUILD_FRAMEWORK=1 -GNinja ../llvm-project/llvm
+```
+
+```
+// Building lldb-mi
+cmake -DCMAKE_PREFIX_PATH=~/buildspace/llvm-inst/ -DUSE_LLDB_FRAMEWORK=1 -GNinja ..
+
+```

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,7 +77,14 @@ add_executable(lldb-mi
 
 set(llvm_deps "")
 
-find_library(lib_lldb NAMES lldb liblldb HINTS ${LLVM_LIBRARY_DIRS})
+set_property(TARGET lldb-mi PROPERTY CXX_STANDARD 14)
+
+if (USE_LLDB_FRAMEWORK)
+  find_library(lib_lldb NAMES LLDB PATHS ${LLVM_BINARY_DIR}/Library/Frameworks)
+else()
+  find_library(lib_lldb NAMES lldb liblldb HINTS ${LLVM_LIBRARY_DIRS})
+endif()
+
 find_library(lib_llvm LLVM HINTS ${LLVM_LIBRARY_DIRS})
 
 if (NOT lib_llvm)


### PR DESCRIPTION
This PR changes the CMakeLists.txt to support building lldb-mi with
LLDB.framework when building LLVM/LLDB with `-DLLDB_BUILD_FRAMEWORK=1`.

When building LLDB-MI, you will need to pass in `USE_LLDB_FRAMEWORK `.

Addresses https://github.com/lldb-tools/lldb-mi/issues/36