### PR TITLE
Fix hexadecimal numbers parsing

### DIFF
--- a/src/MIUtilString.cpp
+++ b/src/MIUtilString.cpp
@@ -413,8 +413,7 @@ bool CMIUtilString::ExtractNumber(MIint64 &vwrNumber) const {
 bool CMIUtilString::ExtractNumberFromHexadecimal(MIint64 &vwrNumber) const {
   vwrNumber = 0;
 
-  const size_t nPos = find_first_not_of("xX01234567890ABCDEFabcedf");
-  if (nPos != std::string::npos)
+  if (!IsHexadecimalNumber())
     return false;
 
   errno = 0;


### PR DESCRIPTION
Current string utilities implementation ignores absence of `0x` during
hexadecimal numbers extraction and it can lead to some non-obvious
bugs. For example, because of this, the debugger understands a
breakpoint on function `f` as a breakpoint on address 0xf.