### PR TITLE
Add install target and set the rpath

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,5 +37,20 @@ if(MSVC)
   add_compile_options("/wd4521")
 endif()
 
-add_subdirectory(src)
+# https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/RPATH-handling
+# use, i.e. don't skip, the full RPATH for the build tree
+SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+# when building, don't use the install RPATH already
+# (but later on when installing)
+SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+# add the automatically determined parts of the RPATH
+# which point to directories outside the build tree to the install RPATH
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+# the RPATH to be used when installing, but only if it's not a system directory
+LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+IF("${isSystemDir}" STREQUAL "-1")
+   SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+ENDIF("${isSystemDir}" STREQUAL "-1")
 
+add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,3 +97,4 @@ endif()
 list(APPEND llvm_deps "${LLVM_PTHREAD_LIB}")
 
 target_link_libraries(lldb-mi ${lib_lldb} ${lib_llvm} ${llvm_deps})
+install( TARGETS lldb-mi)


### PR DESCRIPTION
This allows lldb-mi to be built and installed to an arbitrary directory.