### PR TITLE
Add RUNTIME DESTINATION to install target

### DIFF
--- a/src/MICmdCmdBreak.cpp
+++ b/src/MICmdCmdBreak.cpp
@@ -274,6 +274,7 @@ bool CMICmdCmdBreakInsert::Execute() {
 
     m_brkPt.SetEnabled(m_bBrkPtEnabled);
     m_brkPt.SetIgnoreCount(m_nBrkPtIgnoreCount);
+    m_brkPt.SetOneShot(m_bBrkPtIsTemp);
     if (m_bBrkPtCondition)
       m_brkPt.SetCondition(m_brkPtCondition.c_str());
     if (m_bBrkPtThreadId)


### PR DESCRIPTION
Fix for following build error:
CMake Error at src/CMakeLists.txt:100 (install):
  install TARGETS given no RUNTIME DESTINATION for executable target
  "lldb-mi".