### PR TITLE
Fix handling of RPATH variables on cmake invocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,18 +45,18 @@ endif()
 
 # https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/RPATH-handling
 # use, i.e. don't skip, the full RPATH for the build tree
-SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+SET(CMAKE_SKIP_BUILD_RPATH FALSE CACHE BOOL "")
 # when building, don't use the install RPATH already
 # (but later on when installing)
-SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE CACHE BOOL "")
+SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib" CACHE STRING "")
 # add the automatically determined parts of the RPATH
 # which point to directories outside the build tree to the install RPATH
-SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE CACHE BOOL "")
 # the RPATH to be used when installing, but only if it's not a system directory
 LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
 IF("${isSystemDir}" STREQUAL "-1")
-   SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+   SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib" CACHE STRING "")
 ENDIF("${isSystemDir}" STREQUAL "-1")
 
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ ENDIF("${isSystemDir}" STREQUAL "-1")
 
 add_subdirectory(src)
 
-SET(INCLUDE_TESTS CACHE BOOL FALSE)
+SET(INCLUDE_TESTS FALSE CACHE BOOL "")
 if (INCLUDE_TESTS)
   add_subdirectory(test)
 endif()


### PR DESCRIPTION
Current CMakeLists.txt forces a specific content into the final RPATH,
in particular that it should contain an absolute path to the
installation directory. This is not always optimal, as relocatable
applications on Linux require there to be a path relative to $ORIGIN.
It is possible to ensure that $ORIGIN will be in the RPATH by using a
-Wl,rpath= with a desired value, but this is basically a hack that
bypasses cmake mechanisms. Better approach would be to modify
CMakeLists.txt to respect values that are passed from the command line
via -D option.

Default behavior is not changed by this change.