### PR TITLE
Define NOMINMAX to suppress the min and max macros in Windef.h

### DIFF
--- a/src/MIDataTypes.h
+++ b/src/MIDataTypes.h
@@ -17,6 +17,8 @@
 // Windows headers:
 #ifdef _WIN32
 
+// Suppress the min and max macro definitions in Windef.h.
+#define NOMINMAX
 #include <windows.h>
 
 // Debugging:


### PR DESCRIPTION
Fixes the error reported in #52 