### PR TITLE
Win32: Change incoming path slashes to backslashes in ResolvePath

### DIFF
--- a/src/MICmnLLDBDebugSessionInfo.cpp
+++ b/src/MICmnLLDBDebugSessionInfo.cpp
@@ -323,9 +323,9 @@ bool CMICmnLLDBDebugSessionInfo::ResolvePath(const CMIUtilString &vstrUnknown,
   bool bOk = MIstatus::success;
 
 #ifdef _WIN32
-  // When remote debugging other platforms, incoming paths may have slashes instead of
-  // backslashes. The logic below assumes all paths to have backslashes on Windows,
-  // so do a replace.
+  // When remote debugging other platforms, incoming paths may have slashes
+  // instead of backslashes. The logic below assumes all paths to have
+  // backslashes on Windows, so do a replace.
   std::replace(vwrResolvedPath.begin(), vwrResolvedPath.end(), '/', '\\');
 #endif
 

--- a/src/MICmnLLDBDebugSessionInfo.cpp
+++ b/src/MICmnLLDBDebugSessionInfo.cpp
@@ -11,6 +11,7 @@
 #include <cassert>
 #include <inttypes.h>
 #ifdef _WIN32
+#include <algorithm>
 #include <io.h>
 #else
 #include <unistd.h>
@@ -320,6 +321,13 @@ bool CMICmnLLDBDebugSessionInfo::ResolvePath(const CMIUtilString &vstrUnknown,
   }
 
   bool bOk = MIstatus::success;
+
+#ifdef _WIN32
+  // When remote debugging other platforms, incoming paths may have slashes instead of
+  // backslashes. The logic below assumes all paths to have backslashes on Windows,
+  // so do a replace.
+  std::replace(vwrResolvedPath.begin(), vwrResolvedPath.end(), '/', '\\');
+#endif
 
   CMIUtilString::VecString_t vecPathFolders;
   const MIuint nSplits = vwrResolvedPath.Split(PATH_SEPARATOR, vecPathFolders);


### PR DESCRIPTION
This PR adds a small fix to improve handling of absolute Unix-style paths in Win32 versions of lldb-mi.

Some details about the issue and the suggested fix:

When using lldb-mi to remotely debug a binary on a Linux system, I noticed frequent long stalls (> 10 seconds) when pausing execution or hitting a breakpoint. Further investigation revealed CMICmnLLDBDebugSessionInfo::ResolvePath() as the affected function; the delays were caused by waiting for a call to access() to complete. The path being tested started with two backslashes, and was thus interpreted as an UNC path to a nonexistent network server.

The suggested fix is to switch forward slashes to backslashes in the path to resolve, so the rest of the function will be able to split the path correctly. The reason for the double backslash seems to have been that ResolvePath treats the whole Unix-style path as one element, prepends a backslash, and then switches the slashes (turning the first slash of the original path into the second backslash).

Please let me know in case this is not an appropriate fix for the issue at hand.