### PR TITLE
Avoid warnings by removing 'static' from templates that currently are unused

### DIFF
--- a/src/MICmnLLDBDebugSessionInfo.cpp
+++ b/src/MICmnLLDBDebugSessionInfo.cpp
@@ -869,23 +869,6 @@ void CMICmnLLDBDebugSessionInfo::MIResponseFormWatchpointInfo(
   vwrMiValueResult = CMICmnMIValueResult("wpt", miValueTuple);
 }
 
-template <class T>
-static lldb::SBAddress GetBreakOrWatchPointAddress(lldb::SBTarget &vrTarget,
-                                                   T &vrStoppoint);
-
-template <>
-lldb::SBAddress GetBreakOrWatchPointAddress(lldb::SBTarget &vrTarget,
-                                            lldb::SBBreakpoint &vrStoppoint) {
-  lldb::SBBreakpointLocation breakpointLoc = vrStoppoint.GetLocationAtIndex(0);
-  return breakpointLoc.GetAddress();
-}
-
-template <>
-lldb::SBAddress GetBreakOrWatchPointAddress(lldb::SBTarget &vrTarget,
-                                            lldb::SBWatchpoint &vrStoppoint) {
-  return lldb::SBAddress(vrStoppoint.GetWatchAddress(), vrTarget);
-}
-
 //++
 // Details: Retrieve breakpoint information and write into the given breakpoint
 //          information object. Note not all possible information is retrieved


### PR DESCRIPTION
This fixes warnings like these:

../src/MICmnLLDBDebugSessionInfo.cpp:877:17: warning: unused function 'GetBreakOrWatchPointAddress<lldb::SBBreakpoint>' [-Wunused-function]
lldb::SBAddress GetBreakOrWatchPointAddress(lldb::SBTarget &vrTarget,
                ^
../src/MICmnLLDBDebugSessionInfo.cpp:884:17: warning: unused function 'GetBreakOrWatchPointAddress<lldb::SBWatchpoint>' [-Wunused-function]
lldb::SBAddress GetBreakOrWatchPointAddress(lldb::SBTarget &vrTarget,
                ^

Alternative they could be removed altogether.