### PR TITLE
Remove an unused variable

### DIFF
--- a/src/MICmnLLDBDebugSessionInfoVarObj.cpp
+++ b/src/MICmnLLDBDebugSessionInfoVarObj.cpp
@@ -270,7 +270,6 @@ CMIUtilString CMICmnLLDBDebugSessionInfoVarObj::GetValueStringFormatted(
   if (utilValue.IsIntegerType() || utilValue.IsPointerType()) {
     MIuint64 nValue = 0;
     if (CMICmnLLDBProxySBValue::GetValueAsUnsigned(vrValue, nValue)) {
-      lldb::SBValue &rValue = const_cast<lldb::SBValue &>(vrValue);
       return GetStringFormatted(nValue, defaultValue, veVarFormat);
     }
   }


### PR DESCRIPTION
This became unused in 669a3456a877683c81e3d80016b75b3827a138eb.