### PR TITLE
Consistently include "Platform.h" instead of including <windows.h>

### DIFF
--- a/src/MICmnStreamStdin.cpp
+++ b/src/MICmnStreamStdin.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 // Third Party Headers
-#ifdef _MSC_VER
-#include <windows.h>
+#ifdef _WIN32
+#include "Platform.h"
 #endif
 #include <string.h>
 

--- a/src/MIDataTypes.h
+++ b/src/MIDataTypes.h
@@ -17,9 +17,7 @@
 // Windows headers:
 #ifdef _WIN32
 
-// Suppress the min and max macro definitions in Windef.h.
-#define NOMINMAX
-#include <windows.h>
+#include "Platform.h"
 
 // Debugging:
 #ifdef _DEBUG

--- a/src/MIUtilDebug.cpp
+++ b/src/MIUtilDebug.cpp
@@ -8,7 +8,7 @@
 
 // Third party headers:
 #ifdef _WIN32
-#include <windows.h>
+#include "Platform.h"
 #endif
 
 // In-house headers:

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -14,6 +14,7 @@
 #include <signal.h>
 
 #include "lldb/Host/HostGetOpt.h"
+#include "lldb/Host/windows/PosixApi.h"
 #include "lldb/Host/windows/windows.h"
 
 struct winsize {
@@ -25,7 +26,9 @@ typedef unsigned int speed_t;
 typedef unsigned int tcflag_t;
 
 // fcntl.h // This is not used by MI
+#ifndef O_NOCTTY
 #define O_NOCTTY 0400
+#endif
 
 // ioctls.h
 #define TIOCGWINSZ 0x5413
@@ -50,7 +53,9 @@ typedef long pid_t;
 #endif
 
 #define STDIN_FILENO 0
+#ifndef PATH_MAX
 #define PATH_MAX 32768
+#endif
 #define snprintf _snprintf
 
 extern int ioctl(int d, int request, ...);
@@ -64,12 +69,14 @@ typedef void (*sighandler_t)(int);
 
 // CODETAG_IOR_SIGNALS
 // signal.h
-#define SIGQUIT 3   // Terminal quit signal
-#define SIGKILL 9   // Kill (cannot be caught or ignored)
-#define SIGPIPE 13  // Write on a pipe with no one to read it
-#define SIGCONT 18  // Continue executing, if stopped.
-#define SIGTSTP 20  // Terminal stop signal
-#define SIGSTOP 23  // Stop executing (cannot be caught or ignored)
+#define SIGQUIT 3  // Terminal quit signal
+#define SIGKILL 9  // Kill (cannot be caught or ignored)
+#define SIGPIPE 13 // Write on a pipe with no one to read it
+#define SIGCONT 18 // Continue executing, if stopped.
+#define SIGTSTP 20 // Terminal stop signal
+#ifndef SIGSTOP
+#define SIGSTOP 23 // Stop executing (cannot be caught or ignored)
+#endif
 #define SIGWINCH 28 // (== SIGVTALRM)
 
 #else


### PR DESCRIPTION
Platform.h includes lldb/Host/windows/windows.h, which overrides e.g.
NTDDI_VERSION and _WIN32_WINNT before including <windows.h>. If
we directly include <windows.h> somewhere first, and then later
include lldb/Host/windows/windows.h (via Platform.h) we end up
redefining NTDDI_VERSION.

Also include lldb/Host/windows/PosixApi.h (for consistency, as it
ends up included in some files but not in others) and add ifdefs
around some defines that are defined by lldb's PosixApi.h. (Adding
ifdefs instead of removing the definitions altogether, as older
versions of lldb might not have the same defines.)