### PR TITLE
[CI] Install gmock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ archlinux:
   - ninja
   - cmake
   - gtest
+  - gmock
   script:
   - "./ci/travis.sh"
 


### PR DESCRIPTION
Recently builds started to fail due to the missed dependency on gmock library. Trying to fix builds.