### PR TITLE
Silence warnings about a potentially unused variable

### DIFF
--- a/src/MICmnLLDBDebugSessionInfo.cpp
+++ b/src/MICmnLLDBDebugSessionInfo.cpp
@@ -201,6 +201,7 @@ MIuint CMICmnLLDBDebugSessionInfo::GetOrCreateMiStoppointId(
   auto emplacementStatus =
       m_mapLldbStoppointIdToMiStoppointId.emplace(key, nNewId);
   assert(emplacementStatus.second);
+  MIunused(emplacementStatus);
 
   return nNewId;
 }


### PR DESCRIPTION
If building with asserts disabled, this variable is unused.