### PR TITLE
fix windows build error in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,14 @@ name: LLDB-MI CI
 
 on: [push, pull_request]
 
-jobs:    
+jobs:
   build_and_test:
     name: Build LLDB-MI and run the testsuite
 
     env:
       # CMake build type
       BUILD_TYPE: Release
-      
+
       BUILD_PATH: "'${{github.workspace}}/build'"
 
     runs-on: ${{matrix.os}}
@@ -23,8 +23,8 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
 
       - name: Checkout sources
-        uses: actions/checkout@v2
-  
+        uses: actions/checkout@v3
+
       - name: Check format (Ubuntu)
         run: ${{github.workspace}}/.github/scripts/clang-format.sh
         if: matrix.os == 'ubuntu-latest'
@@ -32,39 +32,41 @@ jobs:
       - name: Install Ninja, LLVM, Clang and LLDB (Mac OS)
         run: |
           brew install ninja llvm
-          echo "LLVM_CONFIG_PATH=$(brew --cellar llvm)/$(brew list --versions llvm | sed -E 's/llvm (.*)/\1/g')/lib/cmake/llvm" >> $GITHUB_ENV       
+          echo "LLVM_CONFIG_PATH=$(brew --cellar llvm)/$(brew list --versions llvm | sed -E 's/llvm (.*)/\1/g')/lib/cmake/llvm" >> $GITHUB_ENV
         if: matrix.os == 'macos-latest'
 
       - name: Install Ninja (Windows)
         run: choco install -y --no-progress ninja
         if: matrix.os == 'windows-latest'
-        
+
       - name: Download LLVM binaries (Windows)
         # Using not yet released feature 'check_artifacts'.
         uses: dawidd6/action-download-artifact@master
         with:
           workflow: ci.yml
           workflow_conclusion: success
-          repo: tkrasnukha/install-llvm
+          repo: sunshaoce/install-llvm
           # Get the last available artifact.
           check_artifacts:  true
         if: matrix.os == 'windows-latest'
-        
+
       # Required to find cl.exe
       - name: Setup devcmd (Windows)
         uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x86
         if: matrix.os == 'windows-latest'
-        
+
       - name: Set up environment (Windows)
         run: |
           $LLVM_CONFIG_PATH = ("${{github.workspace}}").Replace("\", "/") + "/llvm-inst/lib/cmake/llvm"
           echo "LLVM_CONFIG_PATH='$LLVM_CONFIG_PATH'" >> $env:GITHUB_ENV
-          
+
           $CC = (gcm "cl.exe" | select-object -ExpandProperty Definition)
           echo "CC='$CC'" >> $env:GITHUB_ENV
           echo "CXX='$CC'" >> $env:GITHUB_ENV
         if: matrix.os == 'windows-latest'
-      
+
       - name: Configure CMake project
         run: |
           export LLVM_DIR=${{env.LLVM_CONFIG_PATH}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-build
+build*/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ LLDB's machine interface driver.
 
 # Build
 
-lldb-mi uses CMake to build. The only dependencies needed for lldb-mi are a C++14 compiler and LLDB itself (including its dependencies: Clang and LLVM). These dependencies should be installed in a way that they can be found via CMake's [`find_package`](https://cmake.org/cmake/help/latest/command/find_package.html) functionality. You need both the LLDB/Clang/LLVM headers and their compiled libraries for the build to work, but not the respective source files. 
+lldb-mi uses CMake to build. The only dependencies needed for lldb-mi are a C++17 (since LLVM 16) compiler and LLDB itself (including its dependencies: Clang and LLVM). These dependencies should be installed in a way that they can be found via CMake's [`find_package`](https://cmake.org/cmake/help/latest/command/find_package.html) functionality. You need both the LLDB/Clang/LLVM headers and their compiled libraries for the build to work, but not the respective source files.
 
 # Building against system LLDB
 


### PR DESCRIPTION
I noticed that the CI has been failing for a long time because the Windows version of CI depends on the artifact of `tkrasnukha/install-llvm`. However, this repo is no longer usable because the artifact has not been updated for a long time. So I switched repos to fix this issue. At the same time, I also made some other changes. 