### PR TITLE
Add missing cases to MICmnLLDBDebuggerHandleEvents.cpp

### DIFF
--- a/src/MICmnLLDBDebuggerHandleEvents.cpp
+++ b/src/MICmnLLDBDebuggerHandleEvents.cpp
@@ -1171,6 +1171,18 @@ bool CMICmnLLDBDebuggerHandleEvents::HandleProcessEventStateStopped(
   case lldb::eStopReasonInstrumentation:
     pEventType = "eStopReasonInstrumentation";
     break;
+  case lldb::eStopReasonProcessorTrace:
+    pEventType = "eStopReasonProcessorTrace";
+    break;
+  case lldb::eStopReasonFork:
+    pEventType = "eStopReasonFork";
+    break;
+  case lldb::eStopReasonVFork:
+    pEventType = "eStopReasonVFork";
+    break;
+  case lldb::eStopReasonVForkDone:
+    pEventType = "eStopReasonVForkDone";
+    break;
   }
 
   // ToDo: Remove when finished coding application


### PR DESCRIPTION
Add missing switch cases to MICmnLLDBDebuggerHandleEvents.cpp to fix the following warning:
```
/Users/pivovaa/workspace/lldb-mi/src/MICmnLLDBDebuggerHandleEvents.cpp:1133:11: warning: 4 enumeration values not handled in switch: 'eStopReasonProcessorTrace', 'eStopReasonFork', 'eStopReasonVFork'... [-Wswitch]
  switch (eStoppedReason) {
          ^~~~~~~~~~~~~~
/Users/pivovaa/workspace/lldb-mi/src/MICmnLLDBDebuggerHandleEvents.cpp:1133:11: note: add missing switch cases
  switch (eStoppedReason) {
          ^
1 warning generated.
```