### PR TITLE
Fix the problem that the module list cannot be obtained

### DIFF
--- a/src/MICmdCmdBreak.cpp
+++ b/src/MICmdCmdBreak.cpp
@@ -149,7 +149,7 @@ bool CMICmdCmdBreakInsert::Execute() {
   // Ask LLDB for the target to check if we have valid or dummy one.
   CMICmnLLDBDebugSessionInfo &rSessionInfo(
       CMICmnLLDBDebugSessionInfo::Instance());
-  lldb::SBTarget sbTarget = rSessionInfo.GetTarget();
+  lldb::SBTarget sbTarget = rSessionInfo.GetSelectedOrDummyTarget();
 
   m_bBreakpointEnabled = !pArgDisableBreakpoint->GetFound();
   m_bBreakpointIsTemp = pArgTempBreakpoint->GetFound();
@@ -464,7 +464,7 @@ bool CMICmdCmdBreakDelete::Execute() {
   }
 
   bool bSuccess = false;
-  lldb::SBTarget sbTarget = rSessionInfo.GetTarget();
+  lldb::SBTarget sbTarget = rSessionInfo.GetSelectedOrDummyTarget();
   if (sStoppointInfo.m_eType ==
       CMICmnLLDBDebugSessionInfo::eStoppointType_Breakpoint)
     bSuccess = sbTarget.BreakpointDelete(
@@ -601,7 +601,7 @@ bool CMICmdCmdBreakDisable::Execute() {
     }
   };
 
-  lldb::SBTarget sbTarget = rSessionInfo.GetTarget();
+  lldb::SBTarget sbTarget = rSessionInfo.GetSelectedOrDummyTarget();
   if (sStoppointInfo.m_eType ==
       CMICmnLLDBDebugSessionInfo::eStoppointType_Breakpoint) {
     lldb::SBBreakpoint breakpoint = sbTarget.FindBreakpointByID(
@@ -744,7 +744,7 @@ bool CMICmdCmdBreakEnable::Execute() {
     }
   };
 
-  lldb::SBTarget sbTarget = rSessionInfo.GetTarget();
+  lldb::SBTarget sbTarget = rSessionInfo.GetSelectedOrDummyTarget();
   if (sStoppointInfo.m_eType ==
       CMICmnLLDBDebugSessionInfo::eStoppointType_Breakpoint) {
     lldb::SBBreakpoint breakpoint = sbTarget.FindBreakpointByID(
@@ -875,7 +875,7 @@ bool CMICmdCmdBreakAfter::Execute() {
     return MIstatus::failure;
   }
 
-  lldb::SBTarget sbTarget = rSessionInfo.GetTarget();
+  lldb::SBTarget sbTarget = rSessionInfo.GetSelectedOrDummyTarget();
   if (sStoppointInfo.m_eType ==
       CMICmnLLDBDebugSessionInfo::eStoppointType_Breakpoint) {
     lldb::SBBreakpoint breakpoint = sbTarget.FindBreakpointByID(
@@ -1023,7 +1023,7 @@ bool CMICmdCmdBreakCondition::Execute() {
     return MIstatus::failure;
   }
 
-  lldb::SBTarget sbTarget = rSessionInfo.GetTarget();
+  lldb::SBTarget sbTarget = rSessionInfo.GetSelectedOrDummyTarget();
   if (sStoppointInfo.m_eType ==
       CMICmnLLDBDebugSessionInfo::eStoppointType_Breakpoint) {
     lldb::SBBreakpoint breakpoint = sbTarget.FindBreakpointByID(
@@ -1267,7 +1267,7 @@ bool CMICmdCmdBreakWatch::Execute() {
   // Ask LLDB for the target to check if we have valid or dummy one.
   CMICmnLLDBDebugSessionInfo &rSessionInfo(
       CMICmnLLDBDebugSessionInfo::Instance());
-  auto sbTarget = rSessionInfo.GetTarget();
+  auto sbTarget = rSessionInfo.GetSelectedOrDummyTarget();
   auto sbProcess = rSessionInfo.GetProcess();
   auto sbThread = sbProcess.GetSelectedThread();
   auto sbFrame = sbThread.GetSelectedFrame();

--- a/src/MICmdCmdSymbol.cpp
+++ b/src/MICmdCmdSymbol.cpp
@@ -99,7 +99,8 @@ bool CMICmdCmdSymbolListLines::Execute() {
   CMICMDBASE_GETOPTION(pArgFile, File, m_constStrArgNameFile);
 
   const auto &rSessionInfo(CMICmnLLDBDebugSessionInfo::Instance());
-  if (rSessionInfo.GetTarget() == rSessionInfo.GetDebugger().GetDummyTarget()) {
+  if (rSessionInfo.GetSelectedOrDummyTarget() ==
+      rSessionInfo.GetDebugger().GetDummyTarget()) {
     SetError(CMIUtilString::Format(MIRSRC(IDS_CMD_ERR_INVALID_TARGET_CURRENT),
                                    m_cmdData.strMiCmd.c_str()));
     return MIstatus::failure;

--- a/src/MICmnLLDBDebugSessionInfo.cpp
+++ b/src/MICmnLLDBDebugSessionInfo.cpp
@@ -979,13 +979,25 @@ lldb::SBListener &CMICmnLLDBDebugSessionInfo::GetListener() const {
 }
 
 //++
-// Details: Get current target.
+// Details: Get current selected target.
 // Type:    Method.
 // Args:    None.
-// Return:  lldb::SBTarget   - current target.
+// Return:  lldb::SBTarget   - current selected target.
 // Throws:  None.
 //--
 lldb::SBTarget CMICmnLLDBDebugSessionInfo::GetTarget() const {
+  auto target = GetDebugger().GetSelectedTarget();
+  return target;
+}
+
+//++
+// Details: Get current selected or dummy target.
+// Type:    Method.
+// Args:    None.
+// Return:  lldb::SBTarget   - current selected or dummy target.
+// Throws:  None.
+//--
+lldb::SBTarget CMICmnLLDBDebugSessionInfo::GetSelectedOrDummyTarget() const {
   auto target = GetDebugger().GetSelectedTarget();
   if (target.IsValid())
     return target;

--- a/src/MICmnLLDBDebugSessionInfo.h
+++ b/src/MICmnLLDBDebugSessionInfo.h
@@ -204,6 +204,7 @@ public:
   lldb::SBDebugger &GetDebugger() const;
   lldb::SBListener &GetListener() const;
   lldb::SBTarget GetTarget() const;
+  lldb::SBTarget GetSelectedOrDummyTarget() const;
   lldb::SBProcess GetProcess() const;
 
   void SetCreateTty(bool val);


### PR DESCRIPTION
before this patch:
<img width="401" alt="before" src="https://github.com/lldb-tools/lldb-mi/assets/20564099/8671daa4-a03c-46e8-8d15-0b2fe28a3748">
after this patch:
```
(gdb)
-target-attach 43992
^done
=thread-group-started,id="i1",pid="43992"
(gdb)
=thread-created,id="1",group-id="i1"
=thread-created,id="2",group-id="i1"
=thread-created,id="3",group-id="i1"
=thread-selected,id="1"
(gdb)
=library-loaded,id="/usr/lib/dyld",target-name="/usr/lib/dyld",host-name="/usr/lib/dyld",symbols-loaded="0",loaded_addr="0x000000011156a000",size="602112"
=library-loaded,id="/System/Applications/TextEdit.app/Contents/MacOS/TextEdit",target-name="/System/Applications/TextEdit.app/Contents/MacOS/TextEdit",host-name="/System/Applications/TextEdit.app/Contents/MacOS/TextEdit",symbols-loaded="0",loaded_addr="0x0000000101f28000",size="110592"
=library-loaded,id="/System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa",target-name="/System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa",host-name="/System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa",symbols-loaded="0",loaded_addr="0x00007fff33813000",size="4096"
=library-loaded,id="/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation",target-name="/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation",host-name="/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation",symbols-loaded="0",loaded_addr="0x00007fff36d77000",size="3956736"
...
=library-loaded,id="/System/Library/PrivateFrameworks/HelpData.framework/Versions/A/HelpData",target-name="/System/Library/PrivateFrameworks/HelpData.framework/Versions/A/HelpData",host-name="/System/Library/PrivateFrameworks/HelpData.framework/Versions/A/HelpData",symbols-loaded="0",loaded_addr="0x00007fff57ada000",size="196608"
-interpreter-exec console "image list"
~"[  0] EA62F7D4-2AAC-3F7E-AC73-426EFA801BC9 0x0000000101f28000 /System/Applications/TextEdit.app/Contents/MacOS/TextEdit \n[  1] 9F48F7F8-94D0-3793-99B7-DDEF657EF956 0x000000011156a000 /usr/lib/dyld \n[  2] 9C7AC07A-7C05-37D4-910C-E9CDB239AFA8 0x00007fff33813000 /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa \n[  3] 69B915AD-CE6F-3958-8E3A-9D6050989AC2 0x00007fff36d77000 /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation \n[  4] 6DF81160-5E7F-3E31-AA1E-C875E3B98AF6 0x00007fff6d249000 /usr/lib/libobjc.A.dylib \n[  5] 5A20AE6C-BF4D-3689-B7D2-19F0721F6375 0x00007fff6b3e7000 /usr/lib/libSystem.B.dylib \n[  6] 058D0F31-D353-36D9-83CD-1709EBB1390E 0x00007fff3196b000 /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit \n[  7] DFD82191-CCB6-3664-B803-5717036927AC 0x00007fff346b5000 /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation \n ... \n[364] 9F669D19-13AD-3961-B247-ED728B7BFA19 0x00007fff62476000 /System/Library/PrivateFrameworks/Shortcut.framework/Versions/A/Shortcut \n[365] D1922D1C-8EEA-36F8-B7BE-76361A82D15B 0x00007fff57ada000 /System/Library/PrivateFrameworks/HelpData.framework/Versions/A/HelpData \n"
^done
(gdb)
```