### PR TITLE
Temporary fix for memory leak when reading variables

### DIFF
--- a/src/MICmdCmdVar.cpp
+++ b/src/MICmdCmdVar.cpp
@@ -304,7 +304,8 @@ void CMICmdCmdVarCreate::CompleteSBValue(lldb::SBValue &vrwValue) {
   // And update its children
   lldb::SBType valueType = vrwValue.GetType();
   if (!valueType.IsPointerType() && !valueType.IsReferenceType()) {
-    const MIuint nChildren = vrwValue.GetNumChildren();
+    const auto temp = vrwValue.GetNumChildren();
+    const MIuint nChildren = temp > 64 ? 64 : temp;
     for (MIuint i = 0; i < nChildren; ++i) {
       lldb::SBValue member = vrwValue.GetChildAtIndex(i);
       if (member.IsValid())
@@ -597,7 +598,8 @@ bool CMICmdCmdVarUpdate::ExamineSBValueForChange(lldb::SBValue &vrwValue,
     return MIstatus::success;
   }
 
-  const MIuint nChildren = vrwValue.GetNumChildren();
+  const auto temp = vrwValue.GetNumChildren();
+  const MIuint nChildren = temp > 64 ? 64 : temp;
   for (MIuint i = 0; i < nChildren; ++i) {
     lldb::SBValue member = vrwValue.GetChildAtIndex(i);
     if (!member.IsValid())


### PR DESCRIPTION
This is a temporary solution, from @shiretu https://github.com/microsoft/vscode-cpptools/issues/7240#issuecomment-997954449 .
I'm not sure if it really works, so I hope everyone can give more feedback, thank you!

Related issues:
https://github.com/microsoft/vscode-cpptools/issues/1899
https://github.com/microsoft/vscode-cpptools/issues/5805
https://github.com/microsoft/vscode-cpptools/issues/7240
https://github.com/microsoft/vscode-cpptools/issues/9488
https://github.com/microsoft/vscode-cpptools/issues/9831
https://github.com/llvm/llvm-project/issues/53634
https://github.com/lldb-tools/lldb-mi/issues/89
https://github.com/lldb-tools/lldb-mi/issues/101
https://github.com/vadimcn/codelldb/issues/987
https://github.com/vadimcn/codelldb/issues/998

---------

Co-authored-by: Eugen-Andrei Gavriloaie <andrei@gavriloaie.com>