### PR TITLE
Fix target-attach MI command attaching to dummy target

### DIFF
--- a/src/MICmdCmdTarget.cpp
+++ b/src/MICmdCmdTarget.cpp
@@ -263,7 +263,7 @@ bool CMICmdCmdTargetAttach::Execute() {
       CMICmnLLDBDebugSessionInfo::Instance());
 
   // If the current target is invalid, create one
-  lldb::SBTarget target = rSessionInfo.GetTarget();
+  lldb::SBTarget target = rSessionInfo.GetDebugger().GetSelectedTarget();
   if (!target.IsValid()) {
     target = rSessionInfo.GetDebugger().CreateTarget(nullptr);
     if (!target.IsValid()) {


### PR DESCRIPTION
The implementation of the `target-attach` command (`CMICmdCmdTargetAttach::Execute`) tries to search for a selected target to work with, before creating a new one. However, this is not implemented correctly.

The `CMICmnLLDBDebugSessionInfo::GetTarget` function will return the selected target if there is one, and the dummy target otherwise. Effectively, this means that the `!target.IsValid()` check always evaluates to `false`.

Consider a scenario where a user starts an lldb-mi session and issues `-target-attach` as the first command, in which case there is no target yet. lldb-mi will then select the dummy target and attach a process to it, which causes all kinds of odd behavior. For instance, because the dummy target is not 'real' and not included in the target list, all commands operating on actual targets do not work.

We can observe this in practice like so:

```
(gdb)
-target-attach 1234
^done
=thread-group-started,id="i1",pid="1234"
(gdb)
-interpreter-exec console "target list"
~"No targets.\n"
^done
```

Note how the process has been attached, but there is no matching target, leaving the debugger in something of a broken state. The process can be controlled with MI commands:

```
(gdb)
-exec-continue
^running
(gdb)
*running,thread-id="all"
```
... but not inspected with LLDB-specific commands:
```
(gdb)
-interpreter-exec console "bt"
&"error: invalid target, create a target using the 'target create' command\n"
^done
```

This PR resolves this issue by ensuring that `target-attach` will never attempt to bind a process to the dummy target; it should only look for a selected target, and if there is none, create one.