### PR TITLE
Bump the minimum CMake version to match current LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.20.0)
 
 if(POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)

--- a/src/MICmdBase.cpp
+++ b/src/MICmdBase.cpp
@@ -249,8 +249,7 @@ bool CMICmdBase::HandleSBErrorWithSuccess(
 //--
 bool CMICmdBase::HandleSBErrorWithFailure(
     const lldb::SBError &error, const std::function<void()> &errorHandler) {
-  return HandleSBError(
-      error, [] { return MIstatus::success; }, errorHandler);
+  return HandleSBError(error, [] { return MIstatus::success; }, errorHandler);
 }
 
 //++
@@ -262,7 +261,7 @@ bool CMICmdBase::HandleSBErrorWithFailure(
 //--
 MIuint CMICmdBase::GetGUID() {
   MIuint64 vptr = reinterpret_cast<MIuint64>(this);
-  MIuint id = (vptr)&0xFFFFFFFF;
+  MIuint id = (vptr) & 0xFFFFFFFF;
   id ^= (vptr >> 32) & 0xFFFFFFFF;
 
   return id;

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.13)
 
 include(FetchContent)
 FetchContent_Declare(gtest
   QUIET
-  URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
+  URL https://github.com/google/googletest/releases/download/v1.16.0/googletest-1.16.0.tar.gz
 )
 
 # Prevent overriding the parent project's linker settings, for Windows.


### PR DESCRIPTION
CMake 4.0 removed compatibility with CMake versions below 3.5. Therefore, it errors out on projects with a
cmake_minimum_required() less than 3.5.

(Since the last versions of CMake before 4.0, it already has been warning that compatibility with versions below 3.10 is deprecated.)

Thus - this fixes building with CMake 4.0.