### PR TITLE
ci: restrict the permissions of the ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,15 @@ name: LLDB-MI CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build_and_test:
+    permissions:
+      actions: read  # for dawidd6/action-download-artifact to query and download artifacts
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for dawidd6/action-download-artifact to query commit hash
     name: Build LLDB-MI and run the testsuite
 
     env:


### PR DESCRIPTION
Hi! This PR is made by Step Security bot who's used to help us follow the best security practice. [GitHub](https://docs.github.com/en/actions/reference/secure-use-reference#use-secrets-for-sensitive-information) recommends setting minimum token permissions for the GITHUB_TOKEN.
(PS: I'm working for the potential risks of software supply attacks. So I'm trying to write some PRs to help opensource community fix security issues.)