### PR TITLE
Fix error message on failed target attach being discarded

### DIFF
--- a/src/MICmdCmdTarget.cpp
+++ b/src/MICmdCmdTarget.cpp
@@ -290,11 +290,10 @@ bool CMICmdCmdTargetAttach::Execute() {
     return MIstatus::failure;
   }
 
-  lldb::SBStream errMsg;
   if (error.Fail()) {
     SetError(CMIUtilString::Format(MIRSRC(IDS_CMD_ERR_ATTACH_FAILED),
                                    m_cmdData.strMiCmd.c_str(),
-                                   errMsg.GetData()));
+                                   error.GetCString()));
     return MIstatus::failure;
   }
 


### PR DESCRIPTION
If the debugger fails to attach to the specified target, such as due to a permission error, then the error message is accidentally discarded. We create an empty `SBStream` on the stack, write nothing to it, and then use its (empty) contents as error message.

Instead, this PR removes the empty stream and instead passes the actual error message (as generated by lldb) to the formatted output string, so that it properly shows up in the MI output.